### PR TITLE
Add electron build optimization

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,5 +20,18 @@
     "cross-env": "^7.0.3",
     "electron": "^37.2.1",
     "electron-builder": "^26.0.12"
+  },
+  "build": {
+    "asar": true,
+    "files": [
+      "main.js",
+      "index.html",
+      "yopingTemplate.png",
+      "yoping.png",
+      "screen/dist/**",
+      "!**/*.map",
+      "!**/test{,s}/**",
+      "!**/src/**"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,29 @@ npm install
 npm run dev
 ```
 
+### 6. Giảm kích thước build Electron
+
+Để giảm dung lượng package khi build Electron, sử dụng cấu hình `build` trong
+`client/package.json` với tuỳ chọn `asar` và chỉ đưa vào các file cần thiết:
+
+```json
+"build": {
+  "asar": true,
+  "files": [
+    "main.js",
+    "index.html",
+    "yopingTemplate.png",
+    "yoping.png",
+    "screen/dist/**",
+    "!**/*.map",
+    "!**/test{,s}/**",
+    "!**/src/**"
+  ]
+}
+```
+
+Sau khi cập nhật cấu hình, chạy `npm run build` để tạo bản phát hành tối ưu.
+
 ## ✨ Liên kết
 
 - Github: [https://github.com/Yopaz-Co-Ltd/yoping](https://github.com/Yopaz-Co-Ltd/yoping)


### PR DESCRIPTION
## Summary
- configure `electron-builder` to pack only required files using `asar`
- document how to reduce Electron build size

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871e7da806c832a9125678b6dd220ad