### PR TITLE
Add feedback window

### DIFF
--- a/client/feedbackWindow.js
+++ b/client/feedbackWindow.js
@@ -1,0 +1,21 @@
+const { BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+
+function createFeedbackWindow() {
+  const win = new BrowserWindow({
+    width: 400,
+    height: 300,
+    resizable: false,
+    show: true,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  });
+  win.loadFile(path.join(__dirname, 'screen/feedback.html'));
+}
+
+ipcMain.on('open-feedback-window', () => {
+  createFeedbackWindow();
+});
+
+module.exports = { createFeedbackWindow };

--- a/client/main.js
+++ b/client/main.js
@@ -28,7 +28,9 @@ const createTray = () => {
         alwaysOnTop: true,
         skipTaskbar: true,
         webPreferences: {
-          nodeIntegration: true
+          contextIsolation: true,
+          sandbox: false,
+          preload: path.join(__dirname, './preload.js')
         }
       })
       win.loadFile(path.join(__dirname, 'screen/index.html'))

--- a/client/main.js
+++ b/client/main.js
@@ -2,6 +2,7 @@ console.log('Hello from Electron 👋')
 
 const { app, BrowserWindow, Tray, Menu, screen } = require('electron')
 const path = require('path')
+require('./feedbackWindow')
 
 let tray = null
 let win = null

--- a/client/preload.js
+++ b/client/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+contextBridge.exposeInMainWorld('electronAPI', {
+    openFeedback: () => ipcRenderer.send('open-feedback-window')
+});
+console.log('✅ preload script loaded');

--- a/client/screen/feedback.html
+++ b/client/screen/feedback.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <title>Feedback</title>
+  <link rel="stylesheet" href="./public/styles/main.css">
+  <style>
+    body { background: #000; color: #fff; padding: 20px; }
+    .form-group { margin-bottom: 12px; }
+    label { display: block; margin-bottom: 4px; }
+    input { width: 100%; padding: 4px; }
+  </style>
+</head>
+<body>
+  <div class="feedback-form">
+    <div class="form-group">
+      <label for="issue">Vấn đề</label>
+      <input id="issue" type="text" placeholder="Tình trạng mạng gặp phải" />
+    </div>
+    <div class="form-group">
+      <label for="location">Vị trí</label>
+      <input id="location" type="text" placeholder="Sử dụng ở khu vực nào" />
+    </div>
+    <div class="form-group">
+      <label for="network">Mạng sử dụng</label>
+      <input id="network" type="text" placeholder="Tên mạng đang sử dụng" />
+    </div>
+    <div class="form-group">
+      <label for="type">Loại kết nối</label>
+      <input id="type" type="text" placeholder="wifi/dây" />
+    </div>
+  </div>
+</body>
+</html>

--- a/client/screen/index.html
+++ b/client/screen/index.html
@@ -49,4 +49,5 @@
 	</div>
 </body>
 <script src="./public/scripts/main.js"></script>
+<script src="./public/scripts/feedback.js"></script>
 </html>

--- a/client/screen/public/scripts/feedback.js
+++ b/client/screen/public/scripts/feedback.js
@@ -1,0 +1,10 @@
+const { ipcRenderer } = require('electron');
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.querySelector('.more-icon');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      ipcRenderer.send('open-feedback-window');
+    });
+  }
+});

--- a/client/screen/public/scripts/feedback.js
+++ b/client/screen/public/scripts/feedback.js
@@ -1,10 +1,9 @@
-const { ipcRenderer } = require('electron');
-
+// Use exposed API via preload
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.querySelector('.more-icon');
   if (btn) {
     btn.addEventListener('click', () => {
-      ipcRenderer.send('open-feedback-window');
+      window.electronAPI.openFeedback();
     });
   }
 });


### PR DESCRIPTION
## Summary
- trigger open feedback BrowserWindow when clicking the menu icon
- handle window creation in new `feedbackWindow.js`
- add renderer script for click event
- design simple `feedback.html` with required fields

## Testing
- `npx eslint --fix` *(fails: ESLint couldn't find a config)*
- `npm run lint` *(fails: missing script)*
- `go vet ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68760e3b78ec8323b723e37a45db1f07