### PR TITLE
Implement context menu for main screen

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,8 +1,8 @@
 console.log('Hello from Electron 👋')
 
-const { app, BrowserWindow, Tray, Menu, screen } = require('electron')
+const { app, BrowserWindow, Tray, Menu, screen, ipcMain } = require('electron')
 const path = require('path')
-require('./feedbackWindow')
+const { createFeedbackWindow } = require('./feedbackWindow')
 
 let tray = null
 let win = null
@@ -48,6 +48,18 @@ const createTray = () => {
     }
   })
 }
+
+ipcMain.on('show-context-menu', (event) => {
+  const menu = Menu.buildFromTemplate([
+    {
+      label: 'Send Feedback',
+      click: () => createFeedbackWindow()
+    },
+    { label: 'Quit', click: () => app.quit() }
+  ])
+  const win = BrowserWindow.fromWebContents(event.sender)
+  menu.popup({ window: win })
+})
 
 app.whenReady().then(() => {
   if (process.platform === 'darwin') {

--- a/client/preload.js
+++ b/client/preload.js
@@ -1,5 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
+
 contextBridge.exposeInMainWorld('electronAPI', {
-    openFeedback: () => ipcRenderer.send('open-feedback-window')
+  openFeedback: () => ipcRenderer.send('open-feedback-window'),
+  showContextMenu: () => ipcRenderer.send('show-context-menu')
 });
+
 console.log('✅ preload script loaded');

--- a/client/screen/public/scripts/feedback.js
+++ b/client/screen/public/scripts/feedback.js
@@ -2,8 +2,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.querySelector('.more-icon');
   if (btn) {
-    btn.addEventListener('click', () => {
-      window.electronAPI.openFeedback();
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.electronAPI.showContextMenu();
     });
   }
 });


### PR DESCRIPTION
## Summary
- show context menu with Quit and Send Feedback
- add preload bridge for context menu
- update renderer script to request menu

## Testing
- `go vet ./...` *(fails: forbidden - no internet)*
- `npx eslint --fix` *(fails: missing ESLint config)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876201e8ba08323bb2e4816c91acf07