### PR TITLE
[WIP] Implement gradient animation on network status

### DIFF
--- a/client/screen/public/scripts/statusUpdater.js
+++ b/client/screen/public/scripts/statusUpdater.js
@@ -9,7 +9,7 @@ export function updateUI(statusCode) {
   const statusText = statusBox.querySelector('.status-text');
   const popoverTail = document.querySelector('.popover-tail');
 
-  statusBox.classList.remove('network-good', 'network-slow', 'network-offline');
+  statusBox.classList.remove('network-good', 'network-slow', 'network-offline', 'gradient-active');
   popoverTail.classList.remove('network-good', 'network-slow', 'network-offline');
 
   let text = "", className = "";
@@ -33,6 +33,10 @@ export function updateUI(statusCode) {
   }
 
   if (statusText) statusText.textContent = text;
-  if (statusBox) statusBox.classList.add(className);
+  if (statusBox) {
+    statusBox.classList.add(className);
+    void statusBox.offsetWidth;
+    statusBox.classList.add('gradient-active');
+  }
   if (popoverTail) popoverTail.classList.add(className);
 }

--- a/client/screen/public/styles/main.css
+++ b/client/screen/public/styles/main.css
@@ -65,8 +65,20 @@ body {
 }
 
 .status-box {
+  position: relative;
   color: white;
   padding: 18px;
+}
+
+.status-box::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  opacity: 0;
+  transition: opacity 0.4s ease;
 }
 
 .status-header {
@@ -99,11 +111,19 @@ body {
   background: linear-gradient(to bottom, #007EAC, #00547a);
 }
 
+.status-box.network-good::before {
+  background: linear-gradient(to bottom, #007EAC, #00547a);
+}
+
 .status-box.network-good .status-indicator {
   background-color: #00BF63;
 }
 
 .status-box.network-slow {
+  background: linear-gradient(to bottom, #fca53a, #f16375);
+}
+
+.status-box.network-slow::before {
   background: linear-gradient(to bottom, #fca53a, #f16375);
 }
 
@@ -113,6 +133,14 @@ body {
 
 .status-box.network-offline {
   background: linear-gradient(to bottom, #C1356D, #f08977);
+}
+
+.status-box.network-offline::before {
+  background: linear-gradient(to bottom, #C1356D, #f08977);
+}
+
+.status-box.gradient-active::before {
+  opacity: 1;
 }
 
 .status-box.network-offline .status-indicator {


### PR DESCRIPTION
## Summary
- set up pseudo-element overlay on `.status-box`
- animate gradient via new `.gradient-active` class
- adjust `updateUI` to toggle `gradient-active`

## Testing
- `npx eslint --fix public/scripts/statusUpdater.js public/styles/main.css`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687768698e6c8323aa5d111eabaea059