### PR TITLE
Implement gradient transition

### DIFF
--- a/client/screen/public/scripts/statusUpdater.js
+++ b/client/screen/public/scripts/statusUpdater.js
@@ -9,6 +9,12 @@ export function updateUI(statusCode) {
   const statusText = statusBox.querySelector('.status-text');
   const popoverTail = document.querySelector('.popover-tail');
 
+  // Remove gradient to start fade out
+  statusBox.classList.remove('gradient-active');
+  // Force reflow so opacity transition starts
+  void statusBox.offsetWidth;
+
+  // Remove previous status classes
   statusBox.classList.remove('network-good', 'network-slow', 'network-offline');
   popoverTail.classList.remove('network-good', 'network-slow', 'network-offline');
 
@@ -35,4 +41,8 @@ export function updateUI(statusCode) {
   if (statusText) statusText.textContent = text;
   if (statusBox) statusBox.classList.add(className);
   if (popoverTail) popoverTail.classList.add(className);
+
+  // Reflow again before fading in new gradient
+  void statusBox.offsetWidth;
+  statusBox.classList.add('gradient-active');
 }

--- a/client/screen/public/styles/main.css
+++ b/client/screen/public/styles/main.css
@@ -65,8 +65,23 @@ body {
 }
 
 .status-box {
+  position: relative;
   color: white;
   padding: 18px;
+  overflow: hidden;
+}
+
+.status-box::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: -1;
+}
+
+.status-box.gradient-active::before {
+  opacity: 1;
 }
 
 .status-header {
@@ -96,6 +111,10 @@ body {
 }
 
 .status-box.network-good {
+  background-color: #007EAC;
+}
+
+.status-box.network-good::before {
   background: linear-gradient(to bottom, #007EAC, #00547a);
 }
 
@@ -104,6 +123,10 @@ body {
 }
 
 .status-box.network-slow {
+  background-color: #fca53a;
+}
+
+.status-box.network-slow::before {
   background: linear-gradient(to bottom, #fca53a, #f16375);
 }
 
@@ -112,6 +135,10 @@ body {
 }
 
 .status-box.network-offline {
+  background-color: #C1356D;
+}
+
+.status-box.network-offline::before {
   background: linear-gradient(to bottom, #C1356D, #f08977);
 }
 


### PR DESCRIPTION
## Summary
- implement gradient fade transitions for network status updates
- adjust UI styles to support gradient overlay

## Testing
- `npx eslint --fix` *(fails: couldn't find config)*
- `npm run lint` *(fails: missing script)*
- `go vet ./...` *(fails: downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68776bc51f1c8323a6c29cb7a0a2aa66